### PR TITLE
Add studies layer

### DIFF
--- a/benches/value_not_counting_between_threads_benchmark.rs
+++ b/benches/value_not_counting_between_threads_benchmark.rs
@@ -1,15 +1,15 @@
-
 extern crate coding_challenges;
 
-use coding_challenges::value_not_counting_between_threads::{arc_atomic_usize_solution, arc_mutex_solution, arc_rwlock_solution};
+use coding_challenges::value_not_counting_between_threads::{
+    arc_atomic_usize_solution, arc_mutex_solution, arc_rwlock_solution,
+};
 use criterion::{criterion_group, criterion_main, Criterion};
 
 const SAMPLE_SIZE: usize = 10000;
 
-
 fn benchmark_arc_mutex(c: &mut Criterion) {
     let mut group = c.benchmark_group("Arc Mutex Benchmark");
-    group.sample_size(SAMPLE_SIZE); 
+    group.sample_size(SAMPLE_SIZE);
     group.bench_function("Arc<Mutex<usize>>", |b| {
         b.iter(|| arc_mutex_solution());
     });
@@ -18,7 +18,7 @@ fn benchmark_arc_mutex(c: &mut Criterion) {
 
 fn benchmark_atomic_usize(c: &mut Criterion) {
     let mut group = c.benchmark_group("Arc AtomicUsize Benchmark");
-    group.sample_size(SAMPLE_SIZE); 
+    group.sample_size(SAMPLE_SIZE);
     group.bench_function("Arc<AtomicUsize>", |b| {
         b.iter(|| arc_atomic_usize_solution());
     });
@@ -27,12 +27,17 @@ fn benchmark_atomic_usize(c: &mut Criterion) {
 
 fn benchmark_rwlock(c: &mut Criterion) {
     let mut group = c.benchmark_group("Arc RwLock Benchmark");
-    group.sample_size(SAMPLE_SIZE); 
+    group.sample_size(SAMPLE_SIZE);
     group.bench_function("Arc<RwLock<usize>>", |b| {
         b.iter(|| arc_rwlock_solution());
     });
     group.finish();
 }
 
-criterion_group!(benches, benchmark_arc_mutex, benchmark_atomic_usize, benchmark_rwlock);
+criterion_group!(
+    benches,
+    benchmark_arc_mutex,
+    benchmark_atomic_usize,
+    benchmark_rwlock
+);
 criterion_main!(benches);

--- a/src/learn_rust/generics/mod.rs
+++ b/src/learn_rust/generics/mod.rs
@@ -1,0 +1,84 @@
+/*
+Let's model a real-time chat system where users can
+share audio and video files.
+
+Define a DigitalContent enum with two variants:
+AudioFile and VideoFile. Derive a Debug implementation.
+
+Define a ChatMessage struct with two fields: `content`
+and `time`. The struct should define one generic type, T,
+which will be the type of the `content` field.
+The `time` field should always be a String.
+Derive a Debug implementation.
+
+Add an impl block for ChatMessage structs whose T type
+is a DigitalContent enum. Define a `consume_entertainment`
+method that prints out the value of the `content` field in
+Debug format. For example, "Watching the AudioFile".
+
+Add an impl block for ChatMessage structs with any type T.
+Define a `retrieve_time` method that returns a String.
+It should return a clone of the `time` field from
+the struct.
+
+In `main`, create a ChatMessage with `content` set to a
+string slice.
+
+Create another ChatMessage with `content` set to a String.
+
+Create another ChatMessage with `content' set to a
+DigitalContent variant.
+
+Invoke the `consume_entertainment` method on the
+ChatMessage storing a DigitalContent enum.
+
+Invoke the `retrieve_time` method on all 3 ChatMessage
+instances and print out each String's content.
+*/
+
+#[derive(Debug)]
+enum DigitalContent {
+    AudioFile,
+    VideoFile,
+}
+
+#[derive(Debug)]
+struct ChatMessage<T> {
+    content: T,
+    time: String,
+}
+
+impl ChatMessage<DigitalContent> {
+    fn consume_entertainment(&self) {
+        println!("Watching the AudioFile: {:?}", self.content)
+    }
+}
+
+impl<T> ChatMessage<T> {
+    fn retrieve_time(&self) -> String {
+        self.time.clone()
+    }
+}
+
+fn main() {
+    let chat_message_01 = ChatMessage {
+        content: "String Slice Content",
+        time: String::from("02:57pm"),
+    };
+
+    let chat_message_02 = ChatMessage {
+        content: String::from("String Content"),
+        time: String::from("02:58pm"),
+    };
+
+    let chat_message_03 = ChatMessage {
+        content: DigitalContent::AudioFile,
+        time: String::from("03:00pm"),
+    };
+
+    chat_message_03.consume_entertainment();
+
+    chat_message_01.retrieve_time();
+    chat_message_02.retrieve_time();
+    chat_message_03.retrieve_time();
+}

--- a/src/learn_rust/generics/mod.rs
+++ b/src/learn_rust/generics/mod.rs
@@ -50,7 +50,7 @@ struct ChatMessage<T> {
 
 impl ChatMessage<DigitalContent> {
     fn consume_entertainment(&self) {
-        println!("Watching the AudioFile: {:?}", self.content)
+        println!("Watching the {:?}", self.content)
     }
 }
 

--- a/src/learn_rust/generics/mod.rs
+++ b/src/learn_rust/generics/mod.rs
@@ -26,7 +26,7 @@ string slice.
 
 Create another ChatMessage with `content` set to a String.
 
-Create another ChatMessage with `content' set to a
+Create another ChatMessage with `content` set to a
 DigitalContent variant.
 
 Invoke the `consume_entertainment` method on the

--- a/src/learn_rust/mod.rs
+++ b/src/learn_rust/mod.rs
@@ -1,0 +1,1 @@
+pub mod generics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod learn_rust;
 pub mod two_sum;
 pub mod value_not_counting_between_threads;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod learn_rust;
 pub mod two_sum;
 pub mod value_not_counting_between_threads;
+pub mod vec_exercise;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-
+use coding_challenges::vec_exercise::run_impl_iterator_exercise_for_collect_method;
 
 fn main() {
-
+    run_impl_iterator_exercise_for_collect_method();
 }

--- a/src/vec_exercise/mod.rs
+++ b/src/vec_exercise/mod.rs
@@ -42,14 +42,11 @@ impl<'a> Iterator for Splitter<'a> {
             Some(index) => {
                 let result = &self.input[self.start..self.start + index];
                 self.start += index + 1;
-                println!("Result: {:?}", result);
-
                 Some(result)
             }
             None => {
                 let result = &self.input[self.start..];
                 self.start = self.input.len();
-                println!("Result: {:?}", result);
                 Some(result)
             }
         }

--- a/src/vec_exercise/mod.rs
+++ b/src/vec_exercise/mod.rs
@@ -1,0 +1,78 @@
+#[derive(Debug)]
+struct Splitter<'a> {
+    input: &'a str,
+    delimiter: char,
+    start: usize,
+}
+
+impl<'a> Splitter<'a> {
+    fn new(input: &'a str, delimiter: char) -> Self {
+        Splitter {
+            input,
+            delimiter,
+            start: 0,
+        }
+    }
+}
+
+impl<'a> Iterator for Splitter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start > self.input.len() {
+            return None;
+        }
+
+        if self.start == self.input.len() {
+            if self.input.is_empty() {
+                self.start += 1;
+                return Some("");
+            }
+
+            if self.input.chars().last().unwrap() == self.delimiter {
+                self.start += 1;
+                return Some("");
+            }
+            return None;
+        }
+
+        let end = self.input[self.start..].find(self.delimiter);
+
+        match end {
+            Some(index) => {
+                let result = &self.input[self.start..self.start + index];
+                self.start += index + 1;
+                println!("Result: {:?}", result);
+
+                Some(result)
+            }
+            None => {
+                let result = &self.input[self.start..];
+                self.start = self.input.len();
+                println!("Result: {:?}", result);
+                Some(result)
+            }
+        }
+    }
+}
+
+pub fn run_impl_iterator_exercise_for_collect_method() {
+    let test_case = vec![
+        ("Multiple", "ab,cd,ef", ","),
+        ("Multiple", "ab,cd,ef,", ","),
+        ("Multiple", "ab,cd,ef", ":"),
+        ("Multiple", "", ","),
+        ("Multiple", "asasd-3333-asasdsda-d", "-"),
+    ];
+
+    for (name, input, delimiter) in test_case {
+        let delimiter_char = delimiter.chars().next().unwrap();
+        let expected: Vec<_> = input.split(delimiter_char).collect::<Vec<_>>();
+        let splitter = Splitter::new(input, delimiter_char).collect::<Vec<_>>();
+
+        println!("Test: {}", name);
+        println!("Expected: {:?}", expected);
+        println!("Splitter: {:?}", splitter);
+        assert_eq!(expected, splitter);
+    }
+}


### PR DESCRIPTION
This pull request includes several changes across multiple files to add new functionality and improve code organization. The main changes include adding a new module for generics, updating benchmarks, and adding a custom iterator implementation.

### New functionality:

* [`src/learn_rust/generics/mod.rs`](diffhunk://#diff-f5c541a7467db5a59b1630392bd560bf070c0e9e70bcafbb8a7450e46cf1640fR1-R84): Added a new module to model a real-time chat system with `DigitalContent` enum and `ChatMessage` struct, including methods for consuming entertainment and retrieving time.
* [`src/vec_exercise/mod.rs`](diffhunk://#diff-9426b414c095448d111f6deef6c9ac643b987f93c1d08f1e4aad6a90818c237aR1-R75): Implemented a `Splitter` struct and iterator to split strings by a delimiter, along with a function to run tests on the implementation.

### Code organization:

* [`src/learn_rust/mod.rs`](diffhunk://#diff-4f7d8265318be3fa98afa6140777dab587dbf90bd0e04096741e2b290d1a3df1R1): Added a new `generics` module.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R1-R4): Added `learn_rust` and `vec_exercise` modules to the library.
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL1-R4): Updated the `main` function to call the new iterator exercise function.

### Benchmark updates:

* [`benches/value_not_counting_between_threads_benchmark.rs`](diffhunk://#diff-1a254b3bd44e86f60a3bfb330a6da5561b06c64aef9ab95caf153f78b4dd14aaL1-L9): Reformatted imports and updated the `criterion_group!` macro for better readability. [[1]](diffhunk://#diff-1a254b3bd44e86f60a3bfb330a6da5561b06c64aef9ab95caf153f78b4dd14aaL1-L9) [[2]](diffhunk://#diff-1a254b3bd44e86f60a3bfb330a6da5561b06c64aef9ab95caf153f78b4dd14aaL37-R42)